### PR TITLE
Update the reporer to print all lines of trace in issue summary

### DIFF
--- a/R/reporter-buildkite.R
+++ b/R/reporter-buildkite.R
@@ -42,6 +42,23 @@ BuildkiteReporter <- R6::R6Class(
       message <- testthat:::strpad(message, self$width)
       message <- cli::ansi_substr(message, 1, self$width)
       self$cat_tight(self$cr(), message)
+    },
+
+    ## This prints the full trace in the issue_summary
+    ## Default is to truncate this to max 20 lines
+    report_issues = function(issues) {
+      if (issues$size() > 0) {
+        self$rule()
+
+        issues <- issues$as_list()
+        summary <- vapply(issues, testthat:::issue_summary,
+                          FUN.VALUE = character(1),
+                          simplify = "none")
+        self$cat_tight(paste(summary, collapse = "\n\n"))
+
+        self$cat_line()
+        self$rule()
+      }
     }
   )
 )


### PR DESCRIPTION
At the moment (e.g. https://buildkite.com/mrc-ide/naomi/builds/1350#018626d4-f10e-4b80-9d06-bd4a94a8c88d/6-11) testthat truncates the trace of an error or a warning, meaning the interesting part can be excluded. This PR will mean the entire trace is printed in the issue summary.